### PR TITLE
Some improvements and support for Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,9 @@
 A script for Fedora meant to be ran after a fresh install as a quality of life feature for me.
 
 ## How to use
-Clone the repo, run the .sh file on your Fedora 41 system (if you get a permission denied error, be sure to do `chmod a+x` to make it runnable). I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.
+
+1. Clone the repo with `git clone https://github.com/hackisonjd/fedora-fresh-install` and enter the directory with `cd fedora-fresh-install`
+2. Run the .sh file with `./start.sh` on your Fedora 41 system.
+    1. If you get a permission denied error, be sure to do `chmod a+x` to make it runnable.
+
+I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # fedora-fresh-install
 A script for Fedora meant to be ran after a fresh install as a quality of life feature for me.
 
-This fork is one that more reflects my preferences in Fedora.
-
 ## How to use
 Clone the repo, run the .sh file on your Fedora 36 system (be sure to do `chmod a+x` to make it runnable). I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 A script for Fedora meant to be ran after a fresh install as a quality of life feature for me.
 
 ## How to use
-Clone the repo, run the .sh file on your Fedora 36 system (be sure to do `chmod a+x` to make it runnable). I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.
+Clone the repo, run the .sh file on your Fedora 41 system (if you get a permission denied error, be sure to do `chmod a+x` to make it runnable). I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fedora-fresh-install
 A script for Fedora meant to be ran after a fresh install as a quality of life feature for me.
 
+This fork is one that more reflects my preferences in Fedora.
+
 ## How to use
 Clone the repo, run the .sh file on your Fedora 36 system (be sure to do `chmod a+x` to make it runnable). I haven't tested this with any other releases, including Silverblue, so don't get mad at me if they don't work there.

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
-# This script is meant to be run after a fresh install of Fedora 36 as root. If any of these commands change with a new release, I'll edit this script.
+# This script is meant to be run after a fresh install of Fedora 41 as root. If any of these commands change with a new release, I'll edit this script.
+
+# elevate to root if not already
+if [ $EUID != 0 ]; then
+    sudo "$0" "$@"
+    exit $?
+fi
+
+VSCODE="[vscode]'
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc"
 
 # Adds parameters to dnf config file.
 echo "Adding special parameters to dnfconf..."
 sleep 1
 LINE="fastestmirror=True
-max_parallel_downloads=10
-defaultyes=True
-keepcache=True"
+max_parallel_downloads=5
+defaultyes=True"
 FILE="/etc/dnf/dnf.conf"
 if grep -qF -- "$LINE" "$FILE"; then
     echo "dnf.conf already has the special parameters. Skipping..."
@@ -18,23 +30,19 @@ fi
 # Clears cache, then installs updated packages.
 
 echo "Installing updates..."
-sleep 1
 sudo dnf clean all
 sudo dnf update
 
 # Installs RPM Fusion repositories.
 echo "Installing RPM Fusion repositories..."
-sleep 1
 sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
-sudo dnf groupupdate core
+sudo dnf group upgrade core
 
 # Installs Flatpak and Flathub.
 if [ -x "$(command -v flatpak)" ]; then
     echo "Flatpak is already installed. Skipping..."
-    sleep 1
 else
     echo "Installing Flatpak repositories..."
-    sleep 1
     flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 fi
 
@@ -45,16 +53,20 @@ if [ "$ANSWER" = "y" ]; then
     echo "Enter the hostname you want to use:"
     read HOSTNAME
     echo "Setting hostname..."
-    sleep 1
     sudo hostnamectl set-hostname $HOSTNAME
 else
     echo "Skipping hostname change..."
-    sleep 1
+fi
+
+# Optionall add VSCode repository
+echo "Would you like to add the VSCode repository to your system? (y/n)"
+read ANSWER
+if [ "$ANSWER" = "y" ]; then
+    echo "Adding VSCode repository..."
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    echo -e "$VSCODE" > /etc/yum.repos.d/vscode.repo
 fi
 
 # Installs Media Codecs.
 echo "Installing Media Codecs..."
-sleep 1
-sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
-sudo dnf groupupdate sound-and-video
-
+sudo dnf group install multimedia

--- a/start.sh
+++ b/start.sh
@@ -65,6 +65,12 @@ if [ "$ANSWER" = "y" ]; then
     echo "Adding VSCode repository..."
     sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
     echo -e "$VSCODE" > /etc/yum.repos.d/vscode.repo
+
+    echo "Would you like to install VSCode now? (y/n)"
+    read ANSWER
+    if [ "$ANSWER" = "y" ]; then
+        dnf install code
+    fi
 fi
 
 # Installs Media Codecs.

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ if [ $EUID != 0 ]; then
     exit $?
 fi
 
-VSCODE="[vscode]'
+VSCODE="[vscode]
 name=Visual Studio Code
 baseurl=https://packages.microsoft.com/yumrepos/vscode
 enabled=1

--- a/start.sh
+++ b/start.sh
@@ -69,10 +69,13 @@ if [ "$ANSWER" = "y" ]; then
     echo "Would you like to install VSCode now? (y/n)"
     read ANSWER
     if [ "$ANSWER" = "y" ]; then
-        dnf install code
+        sudo dnf install code
     fi
 fi
 
 # Installs Media Codecs.
 echo "Installing Media Codecs..."
-sudo dnf group install multimedia
+sudo dnf swap 'ffmpeg-free' 'ffmpeg' --allowerasing # Switch to full FFMPEG.
+sudo dnf group upgrade multimedia
+sudo dnf upgrade @multimedia --setopt="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin # Installs gstreamer components. Required if you use Gnome Videos and other dependent applications.
+sudo dnf group install -y sound-and-video # Installs useful Sound and Video complement packages.

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This script is meant to be run after a fresh install of Fedora 41 as root. If any of these commands change with a new release, I'll edit this script.
+# https://github.com/devangshekhawat/Fedora-41-Post-Install-Guide
 
 # elevate to root if not already
 if [ $EUID != 0 ]; then
@@ -71,6 +72,14 @@ if [ "$ANSWER" = "y" ]; then
     if [ "$ANSWER" = "y" ]; then
         sudo dnf install code
     fi
+fi
+
+# Windows specific settings
+echo "Are you dual booting with Windows? (y/n)"
+read ANSWER
+if [ "$ANSWER" = "y" ]; then
+    echo "Setting hardware clock to function in local time..."
+    sudo timedatectl set-local-rtc '0'
 fi
 
 # Installs Media Codecs.


### PR DESCRIPTION
- Script automatically elevates itself to root if not already running as root
- Optionally install the VSCode dnf repository/install VSCode itself (a common point of pain to programmers switching to Fedora that I've seen)
- Removed `keepcache=True` and reduced parallel downloads from 10 to 5
- Removed sleep statements for a faster experience
- Replaced `groupupdate` with `group upgrade`
- If dual booting, sets the hwclock to function in local time to prevent the Windows from freaking out
-  Install's ffmpeg full instead of free for better codec support
- Small README updates